### PR TITLE
fix: 修复内容元素被重复监听变化的问题

### DIFF
--- a/src/Nav.js
+++ b/src/Nav.js
@@ -232,16 +232,18 @@ class Nav extends React.PureComponent<Props, State> {
     }
     if (content) {
       if (window.MutationObserver) {
-        this.observe = new MutationObserver(() => {
-          if (!this.props.once) {
-            this.reload();
-          }
-        });
-        const config = {
-          childList: true,
-          subtree: true
-        };
-        this.observe.observe(content, config);
+        if (!this.observe) {
+          this.observe = new MutationObserver(() => {
+            if (!this.props.once) {
+              this.reload();
+            }
+          });
+          const config = {
+            childList: true,
+            subtree: true
+          };
+          this.observe.observe(content, config);
+        }
       } else {
         this.prevInnerHTML = content.innerHTML;
       }


### PR DESCRIPTION
每次“内容元素”发生变化时，都会重复的给“内容元素”加上一个监听，最后导致“内容元素”身上的监听越来越多